### PR TITLE
Update CasADi atmosphere model and fix calculations

### DIFF
--- a/Trajectory_Optimization.py
+++ b/Trajectory_Optimization.py
@@ -208,9 +208,11 @@ def main():
 
     events["massflow"] = 0.0
     events["reference_area"] = 0.0
+    events["aero_enabled"] = True
     for i in events.index:
         stage = stages[str(events.at[i, "rocketStage"])]
         events.at[i, "reference_area"] = stage["reference_area"]
+        events.at[i, "aero_enabled"] = stage.get("aero_enabled", True)
         if events.at[i, "engineOn"]:
             events.at[i, "massflow"] = (
                 events.at[i, "thrust"] / events.at[i, "Isp_vac"] / 9.80665

--- a/atmosphere_casadi.py
+++ b/atmosphere_casadi.py
@@ -37,6 +37,16 @@ def _build_tables():
     return alt_geo, rho, pres, sos
 
 
+def geopotential_altitude(h_geometric):
+    """Convert geometric altitude to geopotential altitude (CasADi compatible)."""
+    return _R_EARTH_ATMO * h_geometric / (_R_EARTH_ATMO + h_geometric)
+
+
+def geometric_altitude(h_geopotential):
+    """Convert geopotential altitude to geometric altitude."""
+    return _R_EARTH_ATMO * h_geopotential / (_R_EARTH_ATMO - h_geopotential)
+
+
 # Build tables once at module load
 _ALT, _RHO, _PRES, _SOS = _build_tables()
 

--- a/atmosphere_casadi.py
+++ b/atmosphere_casadi.py
@@ -18,7 +18,11 @@ def _build_tables():
     """Pre-compute atmosphere tables indexed by geometric altitude.
 
     Fine grid 0–90 km (100 m steps), coarse grid 90–1000 km (1 km steps).
-    Values are evaluated at the corresponding geopotential altitude.
+
+    For each geometric altitude, atmospheric properties are evaluated using
+    ``usatm.geopotential_altitude(h)``: this corresponds to geopotential
+    altitude below about 86 km and to geometric altitude above that, following
+    the US Standard Atmosphere 1976 convention.
     """
     alt_geo_fine = np.arange(0, 90001, 100, dtype=np.float64)
     alt_geo_coarse = np.arange(91000, 1100001, 1000, dtype=np.float64)

--- a/atmosphere_casadi.py
+++ b/atmosphere_casadi.py
@@ -8,69 +8,33 @@
 
 import casadi as ca
 import numpy as np
+import lib.USStandardAtmosphere as usatm
 
 # --- Physical constants ---
-_R_AIR = 287.0531  # specific gas constant for dry air [J/(kg·K)]
-_G0 = 9.80665  # standard gravity [m/s^2]
-_GAMMA = 1.4  # heat capacity ratio
 _R_EARTH_ATMO = 6356766.0  # Earth radius for geopotential altitude [m]
-
-# --- Layer definitions (geopotential altitude) ---
-_H_BASE = [0, 11000, 20000, 32000, 47000, 51000, 71000, 84852]
-_T_BASE = [288.15, 216.65, 216.65, 228.65, 270.65, 270.65, 214.65, 186.946]
-_LAPSE = [-0.0065, 0.0, 0.001, 0.0028, 0.0, -0.0028, -0.002, 0.0]
 
 
 def _build_tables():
-    """Pre-compute atmosphere tables from 0 to 90 km (100 m resolution)."""
-    altitudes = np.arange(0, 90001, 100, dtype=np.float64)
-    n = len(altitudes)
+    """Pre-compute atmosphere tables indexed by geometric altitude.
+
+    Fine grid 0–90 km (100 m steps), coarse grid 90–1000 km (1 km steps).
+    Values are evaluated at the corresponding geopotential altitude.
+    """
+    alt_geo_fine = np.arange(0, 90001, 100, dtype=np.float64)
+    alt_geo_coarse = np.arange(91000, 1100001, 1000, dtype=np.float64)
+    alt_geo = np.concatenate([alt_geo_fine, alt_geo_coarse])
+    n = len(alt_geo)
     rho = np.zeros(n)
     pres = np.zeros(n)
     sos = np.zeros(n)
 
-    # Base pressures at each layer boundary
-    p_base = [101325.0]
-    for layer in range(len(_H_BASE) - 1):
-        h_b = _H_BASE[layer]
-        T_b = _T_BASE[layer]
-        L = _LAPSE[layer]
-        p_b = p_base[-1]
-        dh = _H_BASE[layer + 1] - h_b
-        if abs(L) > 1e-12:
-            p_next = p_b * (T_b / (T_b + L * dh)) ** (_G0 / (_R_AIR * L))
-        else:
-            p_next = p_b * np.exp(-_G0 * dh / (_R_AIR * T_b))
-        p_base.append(p_next)
+    for idx, h in enumerate(alt_geo):
+        h_gp = usatm.geopotential_altitude(h)
+        rho[idx] = usatm.airdensity_at(h_gp)
+        pres[idx] = usatm.airpressure_at(h_gp)
+        sos[idx] = usatm.speed_of_sound(h_gp)
 
-    for idx, h in enumerate(altitudes):
-        # Find layer
-        layer = 0
-        for k in range(len(_H_BASE) - 1):
-            if h >= _H_BASE[k]:
-                layer = k
-        h_b = _H_BASE[layer]
-        T_b = _T_BASE[layer]
-        L = _LAPSE[layer]
-        p_b = p_base[layer]
-        dh = h - h_b
-        T = T_b + L * dh
-
-        if abs(L) > 1e-12:
-            p = p_b * (T_b / T) ** (_G0 / (_R_AIR * L))
-        else:
-            p = p_b * np.exp(-_G0 * dh / (_R_AIR * T_b))
-
-        rho[idx] = p / (_R_AIR * T)
-        pres[idx] = p
-        sos[idx] = np.sqrt(_GAMMA * _R_AIR * T)
-
-    return altitudes, rho, pres, sos
-
-
-def geopotential_altitude(h_geometric):
-    """Convert geometric altitude to geopotential altitude (CasADi compatible)."""
-    return _R_EARTH_ATMO * h_geometric / (_R_EARTH_ATMO + h_geometric)
+    return alt_geo, rho, pres, sos
 
 
 # Build tables once at module load
@@ -81,7 +45,7 @@ def create_atmosphere_interpolants():
     """Create CasADi interpolant functions for density, pressure, speed of sound.
 
     Returns:
-        (density_fn, pressure_fn, sound_speed_fn) — each takes geopotential altitude [m]
+        (density_fn, pressure_fn, sound_speed_fn) — each takes geometric altitude [m]
     """
     density_fn = ca.interpolant("atmo_density", "linear", [_ALT], _RHO)
     pressure_fn = ca.interpolant("atmo_pressure", "linear", [_ALT], _PRES)

--- a/dynamics_casadi.py
+++ b/dynamics_casadi.py
@@ -8,7 +8,6 @@
 
 import casadi as ca
 
-from atmosphere_casadi import geopotential_altitude
 from coordinate_casadi import (
     OMEGA_EARTH,
     conj,
@@ -45,8 +44,7 @@ def _compute_acceleration_impl(
     # --- Geodetic altitude (for atmosphere lookup) ---
     pos_ecef = eci2ecef(pos_eci, t_phys)
     lat_r, lon_r, alt_m = ecef2geodetic(pos_ecef)
-    alt_gp = geopotential_altitude(alt_m)
-    alt_clamp = ca.fmax(0, ca.fmin(alt_gp, 89000))
+    alt_clamp = ca.fmax(0, ca.fmin(alt_m, 1000000))
 
     rho = density_fn(alt_clamp)
     p_atm = pressure_fn(alt_clamp)
@@ -59,7 +57,7 @@ def _compute_acceleration_impl(
 
     # --- Aerodynamic force ---
     # Wind: NED → ECEF → ECI
-    alt_wind = ca.fmax(0, ca.fmin(alt_gp, 89000))
+    alt_wind = ca.fmax(0, ca.fmin(alt_m, 120000))
     w_n = wind_n_fn(alt_wind)
     w_e = wind_e_fn(alt_wind)
     north_ecef, east_ecef = ned_basis_ecef(lat_r, lon_r)
@@ -149,11 +147,10 @@ def angle_of_attack(pos_eci, vel_eci, quat, t_phys, wind_n_fn, wind_e_fn):
     """
     pos_ecef = eci2ecef(pos_eci, t_phys)
     lat_r, lon_r, alt_m = ecef2geodetic(pos_ecef)
-    alt_gp = geopotential_altitude(alt_m)
-    alt_clamp = ca.fmax(0, ca.fmin(alt_gp, 89000))
+    alt_wind = ca.fmax(0, ca.fmin(alt_m, 120000))
 
-    w_n = wind_n_fn(alt_clamp)
-    w_e = wind_e_fn(alt_clamp)
+    w_n = wind_n_fn(alt_wind)
+    w_e = wind_e_fn(alt_wind)
     north_ecef, east_ecef = ned_basis_ecef(lat_r, lon_r)
     wind_ecef = w_n * north_ecef + w_e * east_ecef
     wind_eci = ecef2eci(wind_ecef, t_phys)
@@ -175,13 +172,13 @@ def dynamic_pressure(pos_eci, vel_eci, t_phys, wind_n_fn, wind_e_fn, density_fn)
     """Dynamic pressure [Pa]."""
     pos_ecef = eci2ecef(pos_eci, t_phys)
     lat_r, lon_r, alt_m = ecef2geodetic(pos_ecef)
-    alt_gp = geopotential_altitude(alt_m)
-    alt_clamp = ca.fmax(0, ca.fmin(alt_gp, 89000))
+    alt_clamp_atmo = ca.fmax(0, ca.fmin(alt_m, 1000000))
+    alt_clamp_wind = ca.fmax(0, ca.fmin(alt_m, 120000))
 
-    rho = density_fn(alt_clamp)
+    rho = density_fn(alt_clamp_atmo)
 
-    w_n = wind_n_fn(alt_clamp)
-    w_e = wind_e_fn(alt_clamp)
+    w_n = wind_n_fn(alt_clamp_wind)
+    w_e = wind_e_fn(alt_clamp_wind)
     north_ecef, east_ecef = ned_basis_ecef(lat_r, lon_r)
     wind_ecef = w_n * north_ecef + w_e * east_ecef
     wind_eci = ecef2eci(wind_ecef, t_phys)

--- a/dynamics_casadi.py
+++ b/dynamics_casadi.py
@@ -36,10 +36,17 @@ def _compute_acceleration_impl(
     wind_n_fn,
     wind_e_fn,
     ca_fn,
+    aero_enabled=True,
 ):
     """Core acceleration computation (pure symbolic, no Function wrapping)."""
     # --- Gravity ---
     grav = gravity_eci(pos_eci)
+
+    if not aero_enabled:
+        # No atmosphere dependency — vacuum thrust only, no aero
+        thrust_dir = quatrot(conj(quat), ca.vertcat(1, 0, 0))
+        thrust_eci = thrust_dir * thrust_vac
+        return grav + thrust_eci / mass
 
     # --- Geodetic altitude (for atmosphere lookup) ---
     pos_ecef = eci2ecef(pos_eci, t_phys)
@@ -50,7 +57,7 @@ def _compute_acceleration_impl(
     p_atm = pressure_fn(alt_clamp)
     a_sound = sound_speed_fn(alt_clamp)
 
-    # --- Thrust (body +X axis) ---
+    # --- Thrust (body +X axis) with backpressure correction ---
     thrust_mag = thrust_vac - nozzle_area * p_atm
     thrust_dir = quatrot(conj(quat), ca.vertcat(1, 0, 0))
     thrust_eci = thrust_dir * thrust_mag
@@ -97,6 +104,7 @@ def compute_acceleration(
     wind_n_fn,
     wind_e_fn,
     ca_fn,
+    aero_enabled=True,
 ):
     """Compute translational acceleration in ECI frame [m/s^2].
 
@@ -117,6 +125,7 @@ def compute_acceleration(
         wind_n_fn,
         wind_e_fn,
         ca_fn,
+        aero_enabled=aero_enabled,
     )
 
 

--- a/lib/coordinate.py
+++ b/lib/coordinate.py
@@ -627,7 +627,9 @@ def orbital_elements(r_eci, v_eci):
     e = norm(f_eci) / GMe  # eccentricity
     a = p / (1.0 - e**2)  # semi-major axis
 
-    true_anomaly_rad = acos(f1_eci[0] * nr[0] + f1_eci[1] * nr[1] + f1_eci[2] * nr[2])
+    cos_ta = f1_eci[0] * nr[0] + f1_eci[1] * nr[1] + f1_eci[2] * nr[2]
+    cos_ta = max(-1.0, min(1.0, cos_ta))
+    true_anomaly_rad = acos(cos_ta)
     if v_eci[0] * r_eci[0] + v_eci[1] * r_eci[1] + v_eci[2] * r_eci[2] < 0.0:
         true_anomaly_rad = 2.0 * np.pi - true_anomaly_rad
 

--- a/problem_builder.py
+++ b/problem_builder.py
@@ -47,11 +47,16 @@ def _make_wind_interpolants(wind_table):
     # Ensure strictly increasing grid (deduplicate, sort)
     _, idx = np.unique(alt_gp, return_index=True)
     alt_gp, wn, we = alt_gp[idx], wn[idx], we[idx]
-    # Discard sentinel values beyond 1000 km geopotential
-    valid = alt_gp <= 1000000
+    # Keep only physically meaningful range [0, 1000 km] geopotential
+    valid = (alt_gp >= 0) & (alt_gp <= 1000000)
     alt_gp, wn, we = alt_gp[valid], wn[valid], we[valid]
     # Convert geopotential → geometric altitude for the grid
     alt_geo = geometric_altitude(alt_gp)
+    # Ensure grid starts at 0 m geometric
+    if alt_geo[0] > 0:
+        alt_geo = np.insert(alt_geo, 0, 0.0)
+        wn = np.insert(wn, 0, wn[0])
+        we = np.insert(we, 0, we[0])
     # Extend to 1000 km geometric with last known values if needed
     if alt_geo[-1] < 1000000:
         alt_geo = np.append(alt_geo, 1000000)

--- a/problem_builder.py
+++ b/problem_builder.py
@@ -185,6 +185,7 @@ def build_and_solve(
         massflow = p["massflow"]
         ref_area = p["reference_area"]
         nozzle_area = p["nozzle_area"]
+        aero_enabled = p.get("aero_enabled", True)
 
         # Slices
         m_s = mass[xa:xb]  # (n+1,)
@@ -244,6 +245,7 @@ def build_and_solve(
                 wind_n_fn,
                 wind_e_fn,
                 ca_fn,
+                aero_enabled=aero_enabled,
             )
 
             for dim in range(3):

--- a/problem_builder.py
+++ b/problem_builder.py
@@ -429,6 +429,10 @@ def build_and_solve(
     # ============================================================
     for sec in range(num_sections - 1):
         section_name = pdict["params"][sec]["name"]
+        aero_enabled = pdict["params"][sec].get("aero_enabled", True)
+        if not aero_enabled:
+            continue
+
         ua, ub, xa, xb, n = ps.get_index(sec)
         to_s, tf_s = t[sec], t[sec + 1]
         tau = ps.tau(sec)

--- a/problem_builder.py
+++ b/problem_builder.py
@@ -43,11 +43,14 @@ def _make_wind_interpolants(wind_table):
     # Ensure strictly increasing grid (deduplicate, sort)
     _, idx = np.unique(alt, return_index=True)
     alt, wn, we = alt[idx], wn[idx], we[idx]
-    # Extend to cover the full altitude range if needed
-    if alt[-1] < 200000:
-        alt = np.append(alt, 200000)
-        wn = np.append(wn, 0.0)
-        we = np.append(we, 0.0)
+    # Discard sentinel values beyond 1000 km
+    valid = alt <= 1000000
+    alt, wn, we = alt[valid], wn[valid], we[valid]
+    # Extend to 1000 km geometric with last known values if needed
+    if alt[-1] < 1000000:
+        alt = np.append(alt, 1000000)
+        wn = np.append(wn, wn[-1])
+        we = np.append(we, we[-1])
     fn_n = ca.interpolant("wind_n", "bspline", [alt], wn)
     fn_e = ca.interpolant("wind_e", "bspline", [alt], we)
     return fn_n, fn_e

--- a/problem_builder.py
+++ b/problem_builder.py
@@ -11,7 +11,7 @@ import shutil
 import casadi as ca
 import numpy as np
 
-from atmosphere_casadi import create_atmosphere_interpolants
+from atmosphere_casadi import create_atmosphere_interpolants, geometric_altitude
 from coordinate_casadi import (
     angular_momentum,
     angular_momentum_from_altitude,
@@ -36,23 +36,29 @@ from iip_casadi import iip_latlon
 
 
 def _make_wind_interpolants(wind_table):
-    """Create CasADi interpolants for wind north/east components."""
-    alt = wind_table[:, 0].copy()
+    """Create CasADi interpolants for wind north/east components.
+
+    The wind CSV is indexed by geopotential altitude, but the interpolants
+    are re-indexed by geometric altitude so callers can pass alt_m directly.
+    """
+    alt_gp = wind_table[:, 0].copy()
     wn = wind_table[:, 1].copy()
     we = wind_table[:, 2].copy()
     # Ensure strictly increasing grid (deduplicate, sort)
-    _, idx = np.unique(alt, return_index=True)
-    alt, wn, we = alt[idx], wn[idx], we[idx]
-    # Discard sentinel values beyond 1000 km
-    valid = alt <= 1000000
-    alt, wn, we = alt[valid], wn[valid], we[valid]
+    _, idx = np.unique(alt_gp, return_index=True)
+    alt_gp, wn, we = alt_gp[idx], wn[idx], we[idx]
+    # Discard sentinel values beyond 1000 km geopotential
+    valid = alt_gp <= 1000000
+    alt_gp, wn, we = alt_gp[valid], wn[valid], we[valid]
+    # Convert geopotential → geometric altitude for the grid
+    alt_geo = geometric_altitude(alt_gp)
     # Extend to 1000 km geometric with last known values if needed
-    if alt[-1] < 1000000:
-        alt = np.append(alt, 1000000)
+    if alt_geo[-1] < 1000000:
+        alt_geo = np.append(alt_geo, 1000000)
         wn = np.append(wn, wn[-1])
         we = np.append(we, we[-1])
-    fn_n = ca.interpolant("wind_n", "bspline", [alt], wn)
-    fn_e = ca.interpolant("wind_e", "bspline", [alt], we)
+    fn_n = ca.interpolant("wind_n", "bspline", [alt_geo], wn)
+    fn_e = ca.interpolant("wind_e", "bspline", [alt_geo], we)
     return fn_n, fn_e
 
 

--- a/tools/convert_old_format.py
+++ b/tools/convert_old_format.py
@@ -136,10 +136,15 @@ def convert(old_json_path: Path, out_json_path: Path) -> None:
     # ── RocketStage: remove Isp_vac / dropMass; collect DropMass ────────────────
     rocket_stage_new = {}
     drop_mass = {}
-    for sk, sv in old["RocketStage"].items():
-        rocket_stage_new[sk] = {
+    first_stage = True
+    for sk, sv in sorted(old["RocketStage"].items()):
+        stage_data = {
             k: v for k, v in sv.items() if k not in ("Isp_vac", "dropMass")
         }
+        if not first_stage:
+            stage_data.setdefault("aero_enabled", False)
+        first_stage = False
+        rocket_stage_new[sk] = stage_data
         for dm_name, dm_val in sv.get("dropMass", {}).items():
             drop_mass[dm_name] = dm_val
 

--- a/tools/settings_editor.py
+++ b/tools/settings_editor.py
@@ -398,7 +398,7 @@ def _order_settings(data):
         "IPOPT_options", "SNOPT_options", "sections",
     ]
     STAGE_KEY_ORDER = [
-        "mass_dry", "mass_propellant", "reference_area",
+        "mass_dry", "mass_propellant", "reference_area", "aero_enabled",
         "ignition_at", "cutoff_at", "separation_at",
     ]
     LC_KEY_ORDER = ["lon", "lat", "altitude", "flight_azimuth_init"]

--- a/tools/static/editor.html
+++ b/tools/static/editor.html
@@ -354,6 +354,12 @@ function renderStages() {
       field('reference_area',
         numInput(stage.reference_area, sf('reference_area'), {step:'0.01'}),
         h('span', {className:'unit'}, 'm\u00B2')),
+      field('aero_enabled', (() => {
+        const aeroVal = stage.aero_enabled !== undefined ? stage.aero_enabled : true;
+        const cb = h('input', {type:'checkbox', ...(aeroVal ? {checked:'true'} : {})});
+        cb.addEventListener('change', () => { stage.aero_enabled = cb.checked; markDirty(); });
+        return cb;
+      })()),
       field('ignition_at',
         selectInput(stage.ignition_at, [''].concat(snames), sfSelect('ignition_at'))),
       field('cutoff_at',
@@ -367,7 +373,7 @@ function renderStages() {
     const keys = Object.keys(d.RocketStage).map(Number).filter(n=>!isNaN(n));
     const next = keys.length ? Math.max(...keys) + 1 : 1;
     d.RocketStage[String(next)] = {
-      mass_dry:0, mass_propellant:0, reference_area:0,
+      mass_dry:0, mass_propellant:0, reference_area:0, aero_enabled:true,
       ignition_at:'', cutoff_at:'', separation_at:''
     };
     markDirty(); render();


### PR DESCRIPTION
This pull request introduces a new `aero_enabled` flag for each rocket stage, allowing selective disabling of atmospheric effects for upper stages. It also refactors altitude handling throughout the codebase to consistently use geometric altitude for atmosphere and wind interpolants, improving accuracy and compatibility. Additionally, several improvements were made to data conversion, settings editing, and physical calculations to support these changes.

Atmospheric modeling and altitude handling:

* Refactored `atmosphere_casadi.py` to use geometric altitude for atmosphere tables and interpolants, replacing previous geopotential altitude indexing. Added conversion functions and integrated the US Standard Atmosphere library for physical property calculations. [[1]](diffhunk://#diff-b7d973d200085f96d6bdd6574fc77df1486f8ca25ff784fb95bebba49d4d41a2R11-R49) [[2]](diffhunk://#diff-b7d973d200085f96d6bdd6574fc77df1486f8ca25ff784fb95bebba49d4d41a2L84-R58)
* Updated wind interpolants in `problem_builder.py` to reindex wind tables from geopotential to geometric altitude, ensuring correct altitude handling and coverage up to 1000 km. [[1]](diffhunk://#diff-ca3f3792e7dc8b52cb10ff9b9d7c08c2c0eecf7e824f5a5da8dfbad4a85dea47L14-R14) [[2]](diffhunk://#diff-ca3f3792e7dc8b52cb10ff9b9d7c08c2c0eecf7e824f5a5da8dfbad4a85dea47L39-R61)

Rocket stage configuration and settings:

* Introduced the `aero_enabled` flag in rocket stage definitions, updated data conversion tools to set this flag for upper stages, and modified the settings editor UI and ordering to support and display it. [[1]](diffhunk://#diff-fe609de131bbcb55bd91536b070084e13254880fbf4154541d271eaa3f1d45a6R214-R218) [[2]](diffhunk://#diff-ae6c41e4d4d61485abddc06d5393fd7c166440356ec96107c9b71c1c1ceb6d9bL139-R147) [[3]](diffhunk://#diff-a6df51ba596ee0dea0239f8217ed311e372f4efd1ea7a9447ebb639dd933326eL391-R391) [[4]](diffhunk://#diff-247aafc130b97c0fb62c7046b2673120dcc0a38caee5d707558daca535b7e4b2R357-R362) [[5]](diffhunk://#diff-247aafc130b97c0fb62c7046b2673120dcc0a38caee5d707558daca535b7e4b2L370-R376)

Dynamics and physical calculations:

* Updated dynamics functions to accept and use the `aero_enabled` flag, allowing vacuum-only calculations when disabled. Refactored altitude clamping and wind/atmosphere lookups to use geometric altitude, improving consistency and accuracy. [[1]](diffhunk://#diff-3d31e90b88ae8cb4b4ba8279f150755782a592db83ae94615c0c88da5bbce907L11) [[2]](diffhunk://#diff-3d31e90b88ae8cb4b4ba8279f150755782a592db83ae94615c0c88da5bbce907R39-R67) [[3]](diffhunk://#diff-3d31e90b88ae8cb4b4ba8279f150755782a592db83ae94615c0c88da5bbce907R107) [[4]](diffhunk://#diff-3d31e90b88ae8cb4b4ba8279f150755782a592db83ae94615c0c88da5bbce907R128) [[5]](diffhunk://#diff-3d31e90b88ae8cb4b4ba8279f150755782a592db83ae94615c0c88da5bbce907L152-R162) [[6]](diffhunk://#diff-3d31e90b88ae8cb4b4ba8279f150755782a592db83ae94615c0c88da5bbce907L178-R190) [[7]](diffhunk://#diff-ca3f3792e7dc8b52cb10ff9b9d7c08c2c0eecf7e824f5a5da8dfbad4a85dea47R194) [[8]](diffhunk://#diff-ca3f3792e7dc8b52cb10ff9b9d7c08c2c0eecf7e824f5a5da8dfbad4a85dea47R254)

Numerical robustness:

* Fixed potential domain errors in orbital element calculations by clamping cosine values before calling `acos`.